### PR TITLE
Add su line to logrotate files

### DIFF
--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -70,6 +70,7 @@ describe 'pg_bouncer::configure' do
     it { is_expected.to create_template(logrotate_file) }
     it { is_expected.to create_template(logrotate_file).with(owner: 'root', group: 'root') }
     it { is_expected.to render_file(logrotate_file).with_content(%r{^/var/log/pgbouncer/pgbouncer-test_instance.log}) }
+    it { is_expected.to render_file(logrotate_file).with_content(/su #{username} #{groupname}$/) }
 
     it { is_expected.to create_template(init_file) }
     [

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -41,8 +41,6 @@ describe 'pg_bouncer::configure' do
   let(:username) { 'pgbouncer' }
   let(:groupname) { 'pgbouncer' }
 
-  subject { runner.converge(described_recipe) }
-
   context 'With a single instance, taking all defaults' do
     let(:instance) do
       {
@@ -55,6 +53,9 @@ describe 'pg_bouncer::configure' do
         userlist: { 'username' => 'pa55w0rd' }
       }
     end
+
+    cached(:chef_run) { runner.converge(described_recipe) }
+    subject { chef_run }
 
     it { is_expected.to create_directory('/etc/pgbouncer') }
 
@@ -152,6 +153,9 @@ describe 'pg_bouncer::configure' do
         additional: { 'additional_key' => 'additional_value' }
       }
     end
+
+    cached(:chef_run) { runner.converge(described_recipe) }
+    subject { chef_run }
 
     it { is_expected.to create_directory('/mnt/log/pgbouncer').with(owner: username, group: groupname) }
     it { is_expected.to create_directory('/run/pgbouncer/db_sockets').with(owner: username, group: groupname) }

--- a/spec/recipes/install_spec.rb
+++ b/spec/recipes/install_spec.rb
@@ -27,9 +27,10 @@
 require 'spec_helper'
 
 describe 'pg_bouncer::install' do
+  subject { chef_run }
+
   context 'When all attributes are default, on an unspecified platform' do
-    let(:runner) { ChefSpec::ServerRunner.new }
-    subject { runner.converge(described_recipe) }
+    cached(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
 
     it { is_expected.to install_package('pgbouncer') }
     it { is_expected.to upgrade_package('pgbouncer') }
@@ -39,14 +40,13 @@ describe 'pg_bouncer::install' do
   end
 
   context 'When auto-upgrade is disabled' do
-    let(:runner) do
+    cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
         node.set['pg_bouncer']['upgrade'] = false
         node.set['pg_bouncer']['user'] = 'pguser'
         node.set['pg_bouncer']['group'] = 'pggroup'
-      end
+      end.converge(described_recipe)
     end
-    subject { runner.converge(described_recipe) }
 
     it { is_expected.to install_package('pgbouncer') }
     it { is_expected.not_to upgrade_package('pgbouncer') }
@@ -56,12 +56,11 @@ describe 'pg_bouncer::install' do
   end
 
   context 'When version is pinned' do
-    let(:runner) do
+    cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
         node.set['pg_bouncer']['version'] = '1.2.4-5'
-      end
+      end.converge(described_recipe)
     end
-    subject { runner.converge(described_recipe) }
 
     it { is_expected.to install_package('pgbouncer').with_version('1.2.4-5') }
   end

--- a/templates/default/etc/logrotate.d/pgbouncer-logrotate.d.erb
+++ b/templates/default/etc/logrotate.d/pgbouncer-logrotate.d.erb
@@ -2,6 +2,7 @@
 
 <%= @instance['log_dir'] %>/pgbouncer-<%= @name %>.log {
   daily
+  su <%= @user %> <%= @group %>
   copytruncate
   missingok
   start 0


### PR DESCRIPTION
Logrotate (once loaded) errors on directories that are not owned by root
unless you have a 'su' directive telling it to use that user and group
instead.
