### PR TITLE
fix misplaced alias/name in database definitions

### DIFF
--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -45,8 +45,8 @@ describe 'pg_bouncer::configure' do
     let(:instance) do
       {
         databases: {
-          'dbname' => {
-            alias: 'dbalias',
+          'dbalias' => {
+            name: 'dbname',
             port: 1234
           }
         },
@@ -119,9 +119,9 @@ describe 'pg_bouncer::configure' do
     let(:instance) do
       {
         databases: {
-          'dbname' => {
+          'dbalias' => {
             host: '3.4.5.6',
-            alias: 'dbalias',
+            name: 'dbname',
             port: 1234
           }
         },
@@ -172,7 +172,7 @@ describe 'pg_bouncer::configure' do
       %r{^unix_socket_dir = /run/pgbouncer/db_sockets/$},
       /^auth_type = md4$/,
       %r{^auth_file = /etc/pgbouncer/userlist-test_instance.txt$},
-      /^dbalias = host='3.4.5.6' port=1234 dbname=dbname connect_query='CREATE TABLE Students;'$/,
+      /^dbalias = host=3.4.5.6 port=1234 dbname=dbname connect_query='CREATE TABLE Students;'$/,
       /^admin_users = pgbouncer_god$/,
       /^stats_users = pgbouncer_snitch$/,
       /^pool_mode = session$/,

--- a/templates/default/etc/pgbouncer/pgbouncer.ini.erb
+++ b/templates/default/etc/pgbouncer/pgbouncer.ini.erb
@@ -1,6 +1,6 @@
 [databases]
-<% @instance['databases'].each do |dbname, database| %>
-<%= database[:alias] %> = <%= "host='#{database[:host]}' " unless database[:host].nil? || database[:host].empty? %>port=<%= database[:port] %> dbname=<%= dbname %> <%= "connect_query='#{@instance['connect_query']}'" unless @instance['connect_query'].nil? || @instance['connect_query'].empty? %>
+<% @instance['databases'].each do |dbalias, database| %>
+<%= dbalias %> = <%= "host=#{database[:host]} " unless database[:host].nil? || database[:host].empty? %>port=<%= database[:port] %> dbname=<%= database[:name] %> <%= "connect_query='#{@instance['connect_query']}'" unless @instance['connect_query'].nil? || @instance['connect_query'].empty? %>
 <% end %>
 
 [pgbouncer]


### PR DESCRIPTION
Bollocksed that up good. The alias is the key, the name is part of the
definition.

instances.<NAME>.databases is still a hash, but now instead of

`{ $name: { alias: 'foo', port: 1234}}`

it is

`{ $alias: { name: 'foo', port: 1234 }}`

name is the name of the database on the postgresql server.
